### PR TITLE
Add background gradient shader

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -82,7 +82,12 @@ export default class Game extends Presenter {
       <MainScene>
         <Assets />
 
-        <Sky />
+        <Sky
+          topColor="17 17 25"
+          bottomColor="24 17 17"
+          exponent="1.5"
+          offset="1500.0"
+        />
 
         <Particles />
 

--- a/src/components/Sky.js
+++ b/src/components/Sky.js
@@ -1,8 +1,49 @@
 import { h } from 'preact'
 import { Entity } from 'aframe-react'
 
-const Sky = () => {
-  return <Entity primitive="a-sky" color="#111" width="2048" position="0 0 0" />
+import vertexShader from 'raw-loader!../shaders/skybient.vert'
+import fragmentShader from 'raw-loader!../shaders/skybient.frag'
+
+AFRAME.registerShader('skybient', {
+  schema: {
+    topColor: { type: 'vec3', default: '255 0 0', is: 'uniform' },
+    bottomColor: { type: 'vec3', default: '0 0 255', is: 'uniform' },
+    offset: { type: 'float', default: '400', is: 'uniform' },
+    exponent: { type: 'float', default: '0.6', is: 'uniform' }
+  },
+  vertexShader: vertexShader,
+  fragmentShader: fragmentShader
+})
+
+AFRAME.registerPrimitive('a-skybient', {
+  defaultComponents: {
+    geometry: {
+      primitive: 'sphere',
+      radius: 5000,
+      segmentsWidth: 64,
+      segmentsHeight: 20
+    },
+    material: {
+      shader: 'skybient'
+    },
+    scale: '-1 1 1'
+  },
+
+  mappings: {
+    topColor: 'material.topColor',
+    bottomColor: 'material.bottomColor',
+    offset: 'material.offset',
+    exponent: 'material.exponent'
+  }
+})
+
+const Sky = ({ topColor, bottomColor, exponent, offset }) => {
+  return (
+    <Entity
+      primitive="a-skybient"
+      material={{ shader: 'skybient', topColor, bottomColor, exponent, offset }}
+    />
+  )
 }
 
 export default Sky

--- a/src/shaders/skybient.frag
+++ b/src/shaders/skybient.frag
@@ -16,9 +16,10 @@ void main() {
     b = topColor.z / 255.0;
     vec3 tColor = vec3(r, g, b);
 
-    float h = normalize(vWorldPosition + offset).z;
-    float interp = max( pow( max( -h, 0.0 ), exponent ), 0.0 );
-    vec3 mixedColor = mix(bColor, tColor, interp)
+    float hue = normalize(vWorldPosition + offset).z;
+    float blendFactor = max(pow(max(hue, 0.0),exponent), 0.0);
+    vec3 mixedColor = mix(bColor, tColor, blendFactor);
 
+    // Final color outputted to the screen
     gl_FragColor = vec4(mixedColor, 1.0);
 }

--- a/src/shaders/skybient.frag
+++ b/src/shaders/skybient.frag
@@ -17,7 +17,7 @@ void main() {
     vec3 tColor = vec3(r, g, b);
 
     float hue = normalize(vWorldPosition + offset).z;
-    float blendFactor = max(pow(max(hue, 0.0),exponent), 0.0);
+    float blendFactor = max(pow(max(hue, 0.0), exponent), 0.1);
     vec3 mixedColor = mix(bColor, tColor, blendFactor);
 
     // Final color outputted to the screen

--- a/src/shaders/skybient.frag
+++ b/src/shaders/skybient.frag
@@ -1,0 +1,24 @@
+uniform vec3 bottomColor;
+uniform vec3 topColor;
+uniform float offset;
+uniform float exponent;
+
+varying vec3 vWorldPosition;
+
+void main() {
+    float r = bottomColor.x / 255.0;
+    float g = bottomColor.y / 255.0;
+    float b = bottomColor.z / 255.0;
+    vec3 bColor = vec3(r, g, b);
+
+    r = topColor.x / 255.0;
+    g = topColor.y / 255.0;
+    b = topColor.z / 255.0;
+    vec3 tColor = vec3(r, g, b);
+
+    float h = normalize(vWorldPosition + offset).z;
+    float interp = max( pow( max( -h, 0.0 ), exponent ), 0.0 );
+    vec3 mixedColor = mix(bColor, tColor, interp)
+
+    gl_FragColor = vec4(mixedColor, 1.0);
+}

--- a/src/shaders/skybient.vert
+++ b/src/shaders/skybient.vert
@@ -1,0 +1,8 @@
+varying vec3 vWorldPosition;
+
+void main() {
+	vec4 worldPosition = modelMatrix * vec4(position, 1.0);
+	vWorldPosition = worldPosition.xyz;
+	
+	gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}


### PR DESCRIPTION
This PR adds a background gradient to the whole scene. I'm using GLSL shaders (specifically a fragment shader) to define what each pixel's color is depending on its position in the world, and interpolating their colors using the `topColor` and `bottomColor` values which can pass into as input props.

Resolves #3.